### PR TITLE
Fix path and params

### DIFF
--- a/src/main/scala/com/creatorships/web/comic/catalogs/domain/provider/columns/Path.scala
+++ b/src/main/scala/com/creatorships/web/comic/catalogs/domain/provider/columns/Path.scala
@@ -2,7 +2,7 @@ package com.creatorships.web.comic.catalogs.domain.provider.columns
 
 case class Path(underlying: String) extends AnyVal {
 
-  override def toString: String = if (underlying.headOption.contains('/')) underlying.tail else underlying
+  override def toString: String = if (underlying.headOption.contains('/')) underlying else "/" + underlying
 
   def absoluteWith(url: Url): Url = Url(url.toString + toString)
 

--- a/src/main/scala/com/creatorships/web/comic/catalogs/domain/provider/columns/Url.scala
+++ b/src/main/scala/com/creatorships/web/comic/catalogs/domain/provider/columns/Url.scala
@@ -5,7 +5,7 @@ import net.ruippeixotog.scalascraper.browser.{Browser, JsoupBrowser}
 
 case class Url(underlying: String) extends AnyVal {
 
-  override def toString: String = if (underlying.lastOption.contains('/')) underlying else underlying + '/'
+  override def toString: String = if (underlying.lastOption.contains('/')) underlying.init else underlying
 
   def analyze[T](path: Path)(analyzeRule: AnalyzeRule[T]): Seq[T] = {
     val document = Url.browser.get(toString + path.toString)

--- a/src/main/scala/com/creatorships/web/comic/catalogs/infrastructure/AnalyzeRulesRepository.scala
+++ b/src/main/scala/com/creatorships/web/comic/catalogs/infrastructure/AnalyzeRulesRepository.scala
@@ -30,12 +30,10 @@ case class AnalyzeRulesRepository[F[_]: Monad](transactor: Transactor[F])(implic
          | MAX(IF(styles.analyze_rule_style_type = 'url', styles.selector, '')) as url_selector,
          | MAX(IF(styles.analyze_rule_style_type = 'url', attributes.attribute, NULL)) as url_attribute,
          | MAX(IF(styles.analyze_rule_style_type = 'url', styles.generation, 0)) as url_generation,
-         | MAX(IF(styles.analyze_rule_style_type = 'url', formats.format, NULL)) as url_format,
          | MAX(IF(styles.analyze_rule_style_type = 'url', urls.url, NULL)) as url_url,
          | MAX(IF(styles.analyze_rule_style_type = 'image_url', styles.selector, '')) as image_url_selector,
          | MAX(IF(styles.analyze_rule_style_type = 'image_url', attributes.attribute, NULL)) as image_url_attribute,
          | MAX(IF(styles.analyze_rule_style_type = 'image_url', styles.generation, 0)) as image_url_generation,
-         | MAX(IF(styles.analyze_rule_style_type = 'image_url', formats.format, NULL)) as image_url_format,
          | MAX(IF(styles.analyze_rule_style_type = 'image_url', urls.url, NULL)) as image_url_url
          |FROM
          | analyze_rules rules

--- a/src/main/scala/com/creatorships/web/comic/catalogs/infrastructure/analyze/url/record/Record.scala
+++ b/src/main/scala/com/creatorships/web/comic/catalogs/infrastructure/analyze/url/record/Record.scala
@@ -32,7 +32,6 @@ object Record {
     selector: Selector,
     maybeAttribute: Option[Attribute],
     generation: Generation,
-    maybeFormat: Option[Format],
     maybeUrl: Option[columns.Url]
   ) {
 


### PR DESCRIPTION
### 概要

- 使用していなかった url.format を削除
- url + path する際に、間につける'/' の整合性の付け方を変更